### PR TITLE
Task 1: ANN vs exact k-NN evaluation

### DIFF
--- a/tasks/SOLUTION.md
+++ b/tasks/SOLUTION.md
@@ -1,9 +1,17 @@
 ### Observed values 
 
 ```
-stdout of the solution script for the task
+Average precision@10: 0.9990
+Average ANN query time: 39.50 ms
+Average exact k-NN query time: 97.10 ms
 ```
 
 ### Reflection
 
-Which patterns are present? How can they be explained?  Feel free to describe your findings in detail here. 
+The precision@10 of 0.9990 is basically perfect — across all 100 queries, the ANN search almost always returns the exact same 10 nearest neighbors as the brute-force exact search. That's a really strong result and means the HNSW index is doing its job well for this dataset.
+
+Speed-wise the ANN search comes in at around 39.5 ms versus 97.1 ms for the exact k-NN, so roughly 2.5x faster. That gap will only grow as the collection gets larger — exact search scales linearly with the number of vectors while HNSW is logarithmic, so the trade-off gets increasingly worthwhile at scale.
+
+The high precision makes sense for a dataset like this. The arXiv ML papers tend to cluster naturally around topics (computer vision, NLP, reinforcement learning, etc.), and papers within a cluster are very close to each other in embedding space. That kind of structure is exactly what HNSW is designed to exploit — it builds a graph where nearby vectors are well-connected, so the approximate search rarely misses a true neighbor.
+
+In short: for this collection, HNSW gives us essentially the same quality as an exhaustive search at a fraction of the cost. There's very little reason to use exact search in production here.

--- a/tasks/task_1.py
+++ b/tasks/task_1.py
@@ -1,0 +1,63 @@
+import json
+import time
+
+from qdrant_client import QdrantClient, models
+
+QDRANT_HOST = "localhost"
+QDRANT_PORT = 6333
+COLLECTION_NAME = "arxiv_papers"
+QUERIES_FILE = "../dataset/queries_embeddings.json"
+k = 10
+
+client = QdrantClient(host=QDRANT_HOST, port=QDRANT_PORT)
+
+
+def result_formatting(k, avg_precision, avg_ann_time, avg_knn_time):
+    print(f"Average precision@{k}: {avg_precision:.4f}")
+    print(f"Average ANN query time: {avg_ann_time * 1000:.2f} ms")
+    print(f"Average exact k-NN query time: {avg_knn_time * 1000:.2f} ms")
+
+
+def evaluate_search():
+    with open(QUERIES_FILE, "r", encoding="utf-8") as f:
+        test_dataset = json.load(f)
+
+    precisions = []
+    ann_times = []
+    knn_times = []
+
+    for query, embedding in test_dataset.items():
+        # approximate search (hnsw default)
+        start_ann = time.time()
+        ann_result = client.query_points(
+            collection_name=COLLECTION_NAME,
+            query=embedding,
+            limit=k,
+        ).points
+        ann_times.append(time.time() - start_ann)
+
+        # exact k-nn — slower but gives us the true nearest neighbors to compare against
+        start_knn = time.time()
+        knn_result = client.query_points(
+            collection_name=COLLECTION_NAME,
+            query=embedding,
+            limit=k,
+            search_params=models.SearchParams(exact=True),
+        ).points
+        knn_times.append(time.time() - start_knn)
+
+        # precision@k — how many of the ann results match the exact results
+        ann_ids = set(item.id for item in ann_result)
+        knn_ids = set(item.id for item in knn_result)
+        precision = len(ann_ids.intersection(knn_ids)) / k
+        precisions.append(precision)
+
+    avg_precision = sum(precisions) / len(precisions)
+    avg_ann_time = sum(ann_times) / len(ann_times)
+    avg_knn_time = sum(knn_times) / len(knn_times)
+
+    result_formatting(k, avg_precision, avg_ann_time, avg_knn_time)
+
+
+if __name__ == "__main__":
+    evaluate_search()


### PR DESCRIPTION
## Summary
- Implemented `task_1.py` to compare approximate (HNSW) and exact k-NN search across 100 test queries with k=10
- Calculates precision@10, average ANN time, and average exact k-NN time
- Filled in `SOLUTION.md` with observed values and reflection

## Results
```
Average precision@10: 0.9990
Average ANN query time: 39.50 ms
Average exact k-NN query time: 97.10 ms
```

HNSW achieves 99.9% precision at ~2.5x the speed of brute-force search on this collection.