### PR TITLE
Task 2: evaluate hnsw_ef values

### DIFF
--- a/tasks/SOLUTION.md
+++ b/tasks/SOLUTION.md
@@ -1,4 +1,6 @@
-### Observed values 
+### Task 1 — ANN vs Exact k-NN
+
+#### Observed values
 
 ```
 Average precision@10: 0.9990
@@ -6,7 +8,7 @@ Average ANN query time: 39.50 ms
 Average exact k-NN query time: 97.10 ms
 ```
 
-### Reflection
+#### Reflection
 
 The precision@10 of 0.9990 is basically perfect — across all 100 queries, the ANN search almost always returns the exact same 10 nearest neighbors as the brute-force exact search. That's a really strong result and means the HNSW index is doing its job well for this dataset.
 
@@ -15,3 +17,27 @@ Speed-wise the ANN search comes in at around 39.5 ms versus 97.1 ms for the exac
 The high precision makes sense for a dataset like this. The arXiv ML papers tend to cluster naturally around topics (computer vision, NLP, reinforcement learning, etc.), and papers within a cluster are very close to each other in embedding space. That kind of structure is exactly what HNSW is designed to exploit — it builds a graph where nearby vectors are well-connected, so the approximate search rarely misses a true neighbor.
 
 In short: for this collection, HNSW gives us essentially the same quality as an exhaustive search at a fraction of the cost. There's very little reason to use exact search in production here.
+
+---
+
+### Task 2 — hnsw_ef Tuning
+
+#### Observed values
+
+```
+hnsw_ef=  10 | precision@10: 0.9280 | avg time: 3.43 ms
+hnsw_ef=  20 | precision@10: 0.9750 | avg time: 3.75 ms
+hnsw_ef=  50 | precision@10: 0.9930 | avg time: 4.73 ms
+hnsw_ef= 100 | precision@10: 0.9990 | avg time: 5.52 ms
+hnsw_ef= 200 | precision@10: 1.0000 | avg time: 6.40 ms
+```
+
+#### Reflection
+
+There's a clear trade-off here: higher `hnsw_ef` means more candidates explored during search, which improves precision but costs a bit more time. At `hnsw_ef=10` we're already at 92.8% precision, which is decent but noticeably worse than higher values. By the time you hit `hnsw_ef=200` you're getting perfect precision (1.0000) — basically matching exact k-NN — while still running in just 6.4 ms.
+
+The time differences are actually pretty small in absolute terms (3.4 ms vs 6.4 ms). For most applications the extra couple of milliseconds at higher `hnsw_ef` is worth the precision gain. If you were running millions of queries per second then you'd care more about the lower end, but for typical search workloads `hnsw_ef=100` or `hnsw_ef=200` seems like the sweet spot.
+
+It's also worth noting that these times are much faster than the ANN times from task 1 (39.5 ms). That's probably because task 1 was measuring end-to-end including network overhead across more queries, while these numbers reflect Qdrant running warm with the index already loaded.
+
+The takeaway: `hnsw_ef` is a useful knob when you want to squeeze more precision out of your HNSW index without rebuilding it. For this dataset, anything above 100 gets you to near-perfect recall.

--- a/tasks/SOLUTION.md
+++ b/tasks/SOLUTION.md
@@ -1,9 +1,17 @@
 ### Observed values 
 
 ```
-stdout of the solution script for the task
+Average precision@10: 0.9990
+Average ANN query time: 39.50 ms
+Average exact k-NN query time: 97.10 ms
 ```
 
 ### Reflection
 
-Which patterns are present? How can they be explained?  Feel free to describe your findings in detail here. 
+The precision@10 of 0.9990 is basically perfect — across all 100 queries, the ANN search almost always returns the exact same 10 nearest neighbors as the brute-force exact search. That's a really strong result and means the HNSW index is doing its job well for this dataset.
+
+Speed-wise the ANN search comes in at around 39.5 ms versus 97.1 ms for the exact k-NN, so roughly 2.5x faster. That gap will only grow as the collection gets larger — exact search scales linearly with the number of vectors while HNSW is logarithmic, so the trade-off gets increasingly worthwhile at scale.
+
+The high precision makes sense for a dataset like this. The arXiv ML papers tend to cluster naturally around topics (computer vision, NLP, reinforcement learning, etc.), and papers within a cluster are very close to each other in embedding space. That kind of structure is exactly what HNSW is designed to exploit — it builds a graph where nearby vectors are well-connected, so the approximate search rarely misses a true neighbor.
+
+In short: for this collection, HNSW gives us essentially the same quality as an exhaustive search at a fraction of the cost. There's very little reason to use exact search in production here.

--- a/tasks/task_1.py
+++ b/tasks/task_1.py
@@ -1,0 +1,63 @@
+import json
+import time
+
+from qdrant_client import QdrantClient, models
+
+QDRANT_HOST = "localhost"
+QDRANT_PORT = 6333
+COLLECTION_NAME = "arxiv_papers"
+QUERIES_FILE = "../dataset/queries_embeddings.json"
+k = 10
+
+client = QdrantClient(host=QDRANT_HOST, port=QDRANT_PORT)
+
+
+def result_formatting(k, avg_precision, avg_ann_time, avg_knn_time):
+    print(f"Average precision@{k}: {avg_precision:.4f}")
+    print(f"Average ANN query time: {avg_ann_time * 1000:.2f} ms")
+    print(f"Average exact k-NN query time: {avg_knn_time * 1000:.2f} ms")
+
+
+def evaluate_search():
+    with open(QUERIES_FILE, "r", encoding="utf-8") as f:
+        test_dataset = json.load(f)
+
+    precisions = []
+    ann_times = []
+    knn_times = []
+
+    for query, embedding in test_dataset.items():
+        # approximate search (hnsw default)
+        start_ann = time.time()
+        ann_result = client.query_points(
+            collection_name=COLLECTION_NAME,
+            query=embedding,
+            limit=k,
+        ).points
+        ann_times.append(time.time() - start_ann)
+
+        # exact k-nn — slower but gives us the true nearest neighbors to compare against
+        start_knn = time.time()
+        knn_result = client.query_points(
+            collection_name=COLLECTION_NAME,
+            query=embedding,
+            limit=k,
+            search_params=models.SearchParams(exact=True),
+        ).points
+        knn_times.append(time.time() - start_knn)
+
+        # precision@k — how many of the ann results match the exact results
+        ann_ids = set(item.id for item in ann_result)
+        knn_ids = set(item.id for item in knn_result)
+        precision = len(ann_ids.intersection(knn_ids)) / k
+        precisions.append(precision)
+
+    avg_precision = sum(precisions) / len(precisions)
+    avg_ann_time = sum(ann_times) / len(ann_times)
+    avg_knn_time = sum(knn_times) / len(knn_times)
+
+    result_formatting(k, avg_precision, avg_ann_time, avg_knn_time)
+
+
+if __name__ == "__main__":
+    evaluate_search()

--- a/tasks/task_2.py
+++ b/tasks/task_2.py
@@ -10,7 +10,9 @@ QUERIES_FILE = "../dataset/queries_embeddings.json"
 k = 10
 hnsw_ef_values = [10, 20, 50, 100, 200]
 
-client = QdrantClient(host=QDRANT_HOST, port=QDRANT_PORT)
+# ---
+# bumped timeout to 300s — exact k-NN on 411k vectors is slow and the default times out
+client = QdrantClient(host=QDRANT_HOST, port=QDRANT_PORT, timeout=300)
 
 
 def evaluate_hnsw_ef(k, hnsw_ef_values, test_dataset):
@@ -26,10 +28,12 @@ def evaluate_hnsw_ef(k, hnsw_ef_values, test_dataset):
         ground_truth[query] = set(item.id for item in knn_result)
 
     results = []
-    precisions = []
-    times = []
 
     for hnsw_ef in hnsw_ef_values:
+        # reset for each hnsw_ef value so averages don't bleed across iterations
+        precisions = []
+        times = []
+
         for query, embedding in test_dataset.items():
             start = time.time()
             ann_result = client.query_points(

--- a/tasks/task_2.py
+++ b/tasks/task_2.py
@@ -1,0 +1,64 @@
+import json
+import time
+
+from qdrant_client import QdrantClient, models
+
+QDRANT_HOST = "localhost"
+QDRANT_PORT = 6333
+COLLECTION_NAME = "arxiv_papers"
+QUERIES_FILE = "../dataset/queries_embeddings.json"
+k = 10
+hnsw_ef_values = [10, 20, 50, 100, 200]
+
+client = QdrantClient(host=QDRANT_HOST, port=QDRANT_PORT)
+
+
+def evaluate_hnsw_ef(k, hnsw_ef_values, test_dataset):
+    # run exact search once for each query to use as ground truth
+    ground_truth = {}
+    for query, embedding in test_dataset.items():
+        knn_result = client.query_points(
+            collection_name=COLLECTION_NAME,
+            query=embedding,
+            limit=k,
+            search_params=models.SearchParams(exact=True),
+        ).points
+        ground_truth[query] = set(item.id for item in knn_result)
+
+    results = []
+    precisions = []
+    times = []
+
+    for hnsw_ef in hnsw_ef_values:
+        for query, embedding in test_dataset.items():
+            start = time.time()
+            ann_result = client.query_points(
+                collection_name=COLLECTION_NAME,
+                query=embedding,
+                limit=k,
+                search_params=models.SearchParams(hnsw_ef=hnsw_ef),
+            ).points
+            times.append(time.time() - start)
+
+            ann_ids = set(item.id for item in ann_result)
+            precision = len(ann_ids.intersection(ground_truth[query])) / k
+            precisions.append(precision)
+
+        avg_precision = sum(precisions) / len(precisions)
+        avg_time_ms = (sum(times) / len(times)) * 1000
+
+        results.append({
+            "hnsw_ef": hnsw_ef,
+            "avg_precision": avg_precision,
+            "avg_query_time_ms": avg_time_ms,
+        })
+
+    for r in results:
+        print(f"hnsw_ef={r['hnsw_ef']:>4} | precision@{k}: {r['avg_precision']:.4f} | avg time: {r['avg_query_time_ms']:.2f} ms")
+
+
+if __name__ == "__main__":
+    with open(QUERIES_FILE, "r", encoding="utf-8") as f:
+        test_dataset = json.load(f)
+
+    evaluate_hnsw_ef(k, hnsw_ef_values, test_dataset)


### PR DESCRIPTION
## Summary

- Evaluates `hnsw_ef` values of 10, 20, 50, 100, 200 against exact k-NN ground truth
- Computes average precision@10 and average query time for each value
- Fixed bug from initial version: `precisions` and `times` lists were being accumulated across all `hnsw_ef` iterations instead of being reset per iteration
- Added `timeout=300` to QdrantClient to handle exact k-NN search latency on 411k vectors

## Results

```
hnsw_ef=  10 | precision@10: 0.9280 | avg time: 3.43 ms
hnsw_ef=  20 | precision@10: 0.9750 | avg time: 3.75 ms
hnsw_ef=  50 | precision@10: 0.9930 | avg time: 4.73 ms
hnsw_ef= 100 | precision@10: 0.9990 | avg time: 5.52 ms
hnsw_ef= 200 | precision@10: 1.0000 | avg time: 6.40 ms
```

Higher `hnsw_ef` → better precision, modest time cost. `hnsw_ef=100` hits 0.9990 precision at 5.52 ms — a solid sweet spot for most workloads.