### PR TITLE
Task 2

### DIFF
--- a/scripts/task_2.py
+++ b/scripts/task_2.py
@@ -1,0 +1,99 @@
+from qdrant_client import QdrantClient, models
+from pathlib import Path
+import time, json
+
+
+QDRANT_HOST = "localhost"
+QDRANT_PORT = 6333
+COLLECTION_NAME = 'arxiv_papers'
+SCRIPT_DIR = Path(__file__).resolve().parent
+QUERIES_FILE = SCRIPT_DIR / ".." / "dataset" / "queries_embeddings.json"
+k = 10
+hnsw_ef_values = [10, 20, 50, 100, 200]
+
+client = QdrantClient(host=QDRANT_HOST, port=QDRANT_PORT)
+
+with open(QUERIES_FILE, 'r', encoding='utf-8') as file:
+    test_dataset = json.load(file)
+
+
+def exact_search(k: int, embedding: list):
+    result = client.query_points(
+        collection_name=COLLECTION_NAME,
+        query=embedding,
+        limit=k,
+        with_payload=True,
+        timeout=30,
+        search_params=models.SearchParams(exact=True),
+    ).points
+    return result
+
+    
+def approx_search(k: int, embedding: list, ef: int):
+    result = client.query_points(
+        collection_name=COLLECTION_NAME,
+        query=embedding,
+        limit=k,
+        with_payload=True,
+        timeout=30,
+        search_params=models.SearchParams(hnsw_ef=ef),
+    ).points
+    return result
+
+
+def evaluate_hnsw_ef(k: int, 
+                     hnsw_ef_values: list[int], 
+                     ground_truth: dict[str, list], 
+                     dataset: dict[str, list],
+                     warming=False):
+    results = []
+    for ef in hnsw_ef_values:
+        if not warming:
+            print(f"Running test dataset at hnsw_ef={ef}...")
+        ann_timings = []
+        precision_log = []
+
+        for query, embedding in dataset.items():
+            ann_ids = []
+            start_time = time.time()
+            result = approx_search(k, embedding, ef)
+            if not warming:
+                elapsed_time = time.time() - start_time
+                ann_timings.append(elapsed_time)
+                ann_ids = set([point.id for point in result])
+                knn_ids = set(ground_truth[query])
+                precision = len(ann_ids.intersection(knn_ids)) / k
+                precision_log.append(precision)
+
+        if not warming:
+            avg_precision = sum(precision_log) / len(precision_log)
+            avg_query_time_ms = sum(ann_timings) / len(ann_timings)
+            hnsw_stats = {"hnsw_ef": ef, "avg_precision": avg_precision, "avg_query_time_ms": avg_query_time_ms}
+            results.append(hnsw_stats)
+    return results    
+
+
+def result_formatting(hnsw_stats):
+    print("hnsw_ef evaluation results:")
+    for stat in hnsw_stats:
+        print(f'hnsw_ef: {stat["hnsw_ef"]}, '
+              f'avg_precision: {stat["avg_precision"]:.4f}, '
+              f'avg_query_time_ms: {stat["avg_query_time_ms"] * 1000:.2f}')
+
+
+# Create ground_truth dictionary
+ground_truth = {}
+print("Creating ground_truth dictionary...")
+for query, embedding in test_dataset.items():
+    result = exact_search(k=10, embedding=embedding)
+    ids = [point.id for point in result]
+    ground_truth[query] = ids
+
+# Cache warming
+# Perform evaluate_hnsw_ef with a smaller dataset, and discard the results
+print("Warming cache...")
+evaluate_hnsw_ef(5, [100], ground_truth, test_dataset, warming=True)
+
+# hnsw evaluation
+eval = evaluate_hnsw_ef(k, hnsw_ef_values, ground_truth, test_dataset)
+result_formatting(eval)

--- a/tasks/SOLUTION.md
+++ b/tasks/SOLUTION.md
@@ -1,9 +1,33 @@
 ### Observed values 
 
 ```
-stdout of the solution script for the task
+Creating ground_truth dictionary...
+Warming cache...
+Running test dataset at hnsw_ef=10...
+Running test dataset at hnsw_ef=20...
+Running test dataset at hnsw_ef=50...
+Running test dataset at hnsw_ef=100...
+Running test dataset at hnsw_ef=200...
+hnsw_ef evaluation results:
+hnsw_ef: 10, avg_precision: 0.9430, avg_query_time_ms: 93.47
+hnsw_ef: 20, avg_precision: 0.9780, avg_query_time_ms: 118.22
+hnsw_ef: 50, avg_precision: 0.9980, avg_query_time_ms: 259.73
+hnsw_ef: 100, avg_precision: 1.0000, avg_query_time_ms: 405.47
+hnsw_ef: 200, avg_precision: 1.0000, avg_query_time_ms: 818.71
 ```
 
 ### Reflection
 
 Which patterns are present? How can they be explained? Describe your findings in detail here.
+
+Building on the last exercise, where I observed there seemed to be a point where precision was
+"saturated", meaning the approximate search returned the same results as the exact search
+(precision=1.0). However, this exercise makes it clear that above a certain "exploration factor"
+(hnsw_ef value) with a given dataset all approximate queries will be identical to an exact search
+while benefiting from speed advantages of the approximate search. In the case of the 'arxiv_papers'
+dataset, it appears that hnsw_ef value is between 50-100, with further runs likely able to get
+closer to the actual number.
+
+I think there is likely an importance to finding this optimal/efficient hsnw_ef point for a given
+dataset in order to optimize queries against it. I'm not sure yet what additional variables would
+go into finding this value for a given dataset (indexing, query size, k value?)


### PR DESCRIPTION
## Task

Which task does this PR submit? (delete the ones that don't apply)

- [ X ] Task 2 — Balance the search (`hnsw_ef` sweep)

Branch name: `task-2`

## Summary

I implemented the hnsw_ef sweep in an attempt to isolate optimal value(s) of hnsw_ef for the given dataset. I chose to create functions for exact_search and approx_search in order to make these calls more repeatable in the evaluation, warmup, and ground_truth dictionary creation. This may work better a single 'universal' query modified by submitted parameters, but I think that may make it less understandable.

## Checklist

- [ X ] Qdrant is running locally and the `arxiv_papers` collection from the Vector database with Qdrant project is populated
- [ X ] The script runs end-to-end without errors against the [test dataset](../dataset/queries_embeddings.json)
- [ X ] `tasks/SOLUTION.md` is filled out with the observed values and reflection for this task
- [ X ] This PR targets the correct task branch (one task per PR/branch)
