### PR TITLE
Task 2: Balance the search (`hnsw_ef` sweep)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 ## **Introduction**
+
 This project demonstrates the optimizations of Qdrant, a vector-first database, showcasing how to understand the search quality, balance search speed and accuracy, modify the index, and quantize the stored embeddings.
+
+In the SOLUTION.md you find results and findings/observations for the different runs.
 
 ## **Project Structure**
 
@@ -44,6 +47,7 @@ This project is divided into various tasks that you need to complete. The tasks 
 Each task will contain a collection of resources that will be helpful for you as you solve the task. There are links to topics in Hyperskill, documentation, and other helpful tutorials that you and your team can use. You may not always need to use all the provided resources if you're already familiar with the concepts. In addition to the provided resources, you can always discuss with your teammates and experts.
 
 ## **The flow**
+
 Fork → Clone → Branch → Implement → PR → Review
 
 * Fork this repo to your own GitHub account

--- a/main.py
+++ b/main.py
@@ -4,11 +4,10 @@ import time
 from pathlib import Path
 from dotenv import load_dotenv
 
-
 QUERIES_FILE = Path(__file__).parent / "dataset" / "queries_embeddings.json"
 
 with open(QUERIES_FILE, 'r', encoding='utf-8') as file:
-    test_dataset = json.load(file)
+    test_dataset_queries = json.load(file)
 
 load_dotenv()
 
@@ -17,57 +16,73 @@ QDRANT_PORT = 6333
 COLLECTION_NAME = 'arxiv_papers'
 k = 10
 
-client = QdrantClient(host=QDRANT_HOST, port=QDRANT_PORT)
+client = QdrantClient(host=QDRANT_HOST, port=QDRANT_PORT, timeout=60)
 
-# For each embedding in test_dataset.values() (or each query, embedding pair via test_dataset.items()),
-# Run the exact and the approximate searches, calculate the precision, and log the time for a single query.
 
-ann_times = []
-knn_times = []
-precisions = []
-for query, embedding in test_dataset.items():
-    # Run exact and approximate searches / Log the average time for a single query
-    # Calculate precision / Append the logged times and the precision to their corresponding lists.
+def evaluate_hnsw_ef(k_nearest, hnsw_ef_values, test_dataset):
+    ground_truths = {}
+    # For each embedding in test_dataset.values() (or each query, embedding pair via test_dataset.items()),
+    # run the exact and the approximate searches.
 
-    start_time_ann = time.time()
-    ann_result = client.query_points (
-        collection_name=COLLECTION_NAME,
-        query=embedding,
-        limit=k
-    ).points
-    ann_time = time.time() - start_time_ann
-    ann_times.append(ann_time)
-    # print(f"ANN query time: {ann_time * 1000:.2f} ms")
+    for query, embedding in test_dataset.items():
+        knn_result = client.query_points(
+            collection_name=COLLECTION_NAME,
+            query=embedding,
+            limit=k,
+            search_params=models.SearchParams (exact=True)
+        ).points
+        ground_truths[query] = set(item.id for item in knn_result)
 
-    start_time_knn = time.time()
-    knn_result = client.query_points(
-        collection_name=COLLECTION_NAME,
-        query=embedding,
-        limit=k,
-        search_params=models.SearchParams(exact=True),
-    ).points
-    knn_time = time.time() - start_time_knn
-    knn_times.append(knn_time)
-    # print(f"KNN query time: {knn_time * 1000:.2f} ms")
+    results = []
+    warmup_embedding = next(iter(test_dataset.values()))
 
-    ann_ids = set(item.id for item in ann_result)
-    knn_ids = set(item.id for item in knn_result)
-    precision = len(ann_ids.intersection(knn_ids)) / k
-    precisions.append(precision)
-    # print(f"Precision@{k}: {precision:.4f}")
+    for hnsw_ef in hnsw_ef_values:
+        ann_times = {hnsw_ef: []}
+        precisions = {hnsw_ef: []}
 
-averages = {
-    "avg_ann_time": sum(ann_times) / len(ann_times),
-    "avg_knn_time": sum(knn_times) / len(knn_times),
-    "avg_precision": sum(precisions) / len(precisions),
-}
+        # Warm up cache
+        for _ in range (5):
+            client.query_points (
+                collection_name=COLLECTION_NAME,
+                query=warmup_embedding,
+                limit=k_nearest,
+                search_params=models.SearchParams (hnsw_ef=hnsw_ef),
+            )
+        for query, embedding in test_dataset.items():
+            # Run exact and approximate searches / Log the average time for a single query
+            # Calculate precision / Append the logged times and the precision to their corresponding lists.
 
-# Display the averages and write up a reflection on the obtained results
-def result_formatting(k, avg_precision, avg_ann_time, avg_knn_time):
-    print(f'Average precision@{k}: {avg_precision:.4f}')
-    print(f'Average ANN query time: {avg_ann_time * 1000:.2f} ms')
-    print(f'Average exact k-NN query time: {avg_knn_time * 1000:.2f} ms')
+            start_time_ann = time.time()
+            ann_result = client.query_points (
+                collection_name=COLLECTION_NAME,
+                query=embedding,
+                limit=k_nearest,
+                search_params=models.SearchParams (hnsw_ef=hnsw_ef)  # the modification
+            ).points
+            ann_time = time.time() - start_time_ann
+            ann_times[hnsw_ef].append(ann_time)
+
+            ann_ids = set(item.id for item in ann_result)
+            knn_ids = ground_truths[query]
+            precision = len(ann_ids.intersection(knn_ids)) / k_nearest
+            precisions[hnsw_ef].append(precision)
+
+        avg_precision = sum (precisions[hnsw_ef]) / len (precisions[hnsw_ef])
+        avg_query_time_ms = (sum (ann_times[hnsw_ef]) / len (ann_times[hnsw_ef])) * 1000  # sec -> ms
+
+        results.append ({
+            "hnsw_ef": hnsw_ef,
+            "avg_precision": avg_precision,
+            "avg_query_time_ms": avg_query_time_ms,
+        })
+
+    for row in results:
+        print (
+            f"hnsw_ef={row['hnsw_ef']:>3} | "
+            f"avg_precision={row['avg_precision']:.4f} | "
+            f"avg_query_time={row['avg_query_time_ms']:.2f} ms"
+        )
 
 
 if __name__ == "__main__":
-    result_formatting (10, averages["avg_precision"], averages["avg_ann_time"], averages["avg_knn_time"])
+    evaluate_hnsw_ef(10, [10, 20, 50, 100, 200], test_dataset_queries)

--- a/main.py
+++ b/main.py
@@ -1,14 +1,12 @@
 from qdrant_client import QdrantClient, models
 import json
 import time
+from pathlib import Path
 from dotenv import load_dotenv
 
-# OK Run the Qdrant Docker image (see stage 1 of the Vector database with Qdrant project);
-# OK Download the test dataset that will be used for the calculation.
-#    It is a JSON file with 100 queries and their corresponding text-embedding-ada-002 embeddings. The queries are stored as the keys, and the embeddings are stored as the values.
-# Load the dataset with the script:
 
-QUERIES_FILE = "C:/Users/frank/PycharmProjects/HyperskillAI/further-steps-with-qdrant/dataset/queries_embeddings.json"
+QUERIES_FILE = Path(__file__).parent / "dataset" / "queries_embeddings.json"
+
 with open(QUERIES_FILE, 'r', encoding='utf-8') as file:
     test_dataset = json.load(file)
 
@@ -23,16 +21,13 @@ client = QdrantClient(host=QDRANT_HOST, port=QDRANT_PORT)
 
 # For each embedding in test_dataset.values() (or each query, embedding pair via test_dataset.items()),
 # Run the exact and the approximate searches, calculate the precision, and log the time for a single query.
-# The precision of a single query can be calculated as
 
 ann_times = []
 knn_times = []
 precisions = []
 for query, embedding in test_dataset.items():
-    # Run exact and approximate searches
-    # Log the average time for a single query
-    # Calculate precision
-    # Append the logged times and the precision to their corresponding lists.
+    # Run exact and approximate searches / Log the average time for a single query
+    # Calculate precision / Append the logged times and the precision to their corresponding lists.
 
     start_time_ann = time.time()
     ann_result = client.query_points (
@@ -76,10 +71,3 @@ def result_formatting(k, avg_precision, avg_ann_time, avg_knn_time):
 
 if __name__ == "__main__":
     result_formatting (10, averages["avg_precision"], averages["avg_ann_time"], averages["avg_knn_time"])
-
-    # FILE_PATH = "C:/Users/Frank/Documents/Backup/AI Sp3 data/ml-arxiv-embeddings.json"
-    # path = FILE_PATH or os.getenv("FILE_PATH")
-    #
-    # print(f"Main> Path to use={path}")
-    # load_vectors_to_qdrant(path)
-    #

--- a/main.py
+++ b/main.py
@@ -1,0 +1,85 @@
+from qdrant_client import QdrantClient, models
+import json
+import time
+from dotenv import load_dotenv
+
+# OK Run the Qdrant Docker image (see stage 1 of the Vector database with Qdrant project);
+# OK Download the test dataset that will be used for the calculation.
+#    It is a JSON file with 100 queries and their corresponding text-embedding-ada-002 embeddings. The queries are stored as the keys, and the embeddings are stored as the values.
+# Load the dataset with the script:
+
+QUERIES_FILE = "C:/Users/frank/PycharmProjects/HyperskillAI/further-steps-with-qdrant/dataset/queries_embeddings.json"
+with open(QUERIES_FILE, 'r', encoding='utf-8') as file:
+    test_dataset = json.load(file)
+
+load_dotenv()
+
+QDRANT_HOST = "localhost"
+QDRANT_PORT = 6333
+COLLECTION_NAME = 'arxiv_papers'
+k = 10
+
+client = QdrantClient(host=QDRANT_HOST, port=QDRANT_PORT)
+
+# For each embedding in test_dataset.values() (or each query, embedding pair via test_dataset.items()),
+# Run the exact and the approximate searches, calculate the precision, and log the time for a single query.
+# The precision of a single query can be calculated as
+
+ann_times = []
+knn_times = []
+precisions = []
+for query, embedding in test_dataset.items():
+    # Run exact and approximate searches
+    # Log the average time for a single query
+    # Calculate precision
+    # Append the logged times and the precision to their corresponding lists.
+
+    start_time_ann = time.time()
+    ann_result = client.query_points (
+        collection_name=COLLECTION_NAME,
+        query=embedding,
+        limit=k
+    ).points
+    ann_time = time.time() - start_time_ann
+    ann_times.append(ann_time)
+    # print(f"ANN query time: {ann_time * 1000:.2f} ms")
+
+    start_time_knn = time.time()
+    knn_result = client.query_points(
+        collection_name=COLLECTION_NAME,
+        query=embedding,
+        limit=k,
+        search_params=models.SearchParams(exact=True),
+    ).points
+    knn_time = time.time() - start_time_knn
+    knn_times.append(knn_time)
+    # print(f"KNN query time: {knn_time * 1000:.2f} ms")
+
+    ann_ids = set(item.id for item in ann_result)
+    knn_ids = set(item.id for item in knn_result)
+    precision = len(ann_ids.intersection(knn_ids)) / k
+    precisions.append(precision)
+    # print(f"Precision@{k}: {precision:.4f}")
+
+averages = {
+    "avg_ann_time": sum(ann_times) / len(ann_times),
+    "avg_knn_time": sum(knn_times) / len(knn_times),
+    "avg_precision": sum(precisions) / len(precisions),
+}
+
+# Display the averages and write up a reflection on the obtained results
+def result_formatting(k, avg_precision, avg_ann_time, avg_knn_time):
+    print(f'Average precision@{k}: {avg_precision:.4f}')
+    print(f'Average ANN query time: {avg_ann_time * 1000:.2f} ms')
+    print(f'Average exact k-NN query time: {avg_knn_time * 1000:.2f} ms')
+
+
+if __name__ == "__main__":
+    result_formatting (10, averages["avg_precision"], averages["avg_ann_time"], averages["avg_knn_time"])
+
+    # FILE_PATH = "C:/Users/Frank/Documents/Backup/AI Sp3 data/ml-arxiv-embeddings.json"
+    # path = FILE_PATH or os.getenv("FILE_PATH")
+    #
+    # print(f"Main> Path to use={path}")
+    # load_vectors_to_qdrant(path)
+    #

--- a/tasks/SOLUTION.md
+++ b/tasks/SOLUTION.md
@@ -1,7 +1,7 @@
 ### Observed values 
 
 ```
-TASK 3 - k-NN vs approximate search
+TASK 3 - Quantization
 TO DO
 
 TASK 2 - Balance the search: Fine-tuning search parameters (e.g. hsnw-ef)
@@ -17,7 +17,7 @@ hnsw_ef= 50 | avg_precision=0.9980 | avg_query_time=14.91 ms
 hnsw_ef=100 | avg_precision=0.9990 | avg_query_time=14.63 ms
 hnsw_ef=200 | avg_precision=0.9990 | avg_query_time=16.29 ms
 
-TASK 1 - Quantization
+TASK 1 - k-NN vs approximate search
 Average precision@10: 0.9990
 Average ANN query time: 16.39 ms
 Average exact k-NN query time: 109.97 ms
@@ -34,7 +34,7 @@ Average exact k-NN query time: 98.38 ms
 
 ### Reflection
 
-TASK 3 - k-NN vs approximate search
+TASK 3 - Quantization
 
 
 TASK 2 - Balance the search: Fine-tuning search parameters (e.g. hsnw-ef)
@@ -42,7 +42,7 @@ TASK 2 - Balance the search: Fine-tuning search parameters (e.g. hsnw-ef)
 2. While the average execution speed remains more or less the same for each value of hnsw_ef
 3. So we propose to use a value for hnsw_ef of 50. 
 
-TASK 1 - Quantization
+TASK 1 - k-NN vs approximate search
 After (forced) creating an index on the Qdrant client we get this better results.
 1. The precision@10 is 0.9990 or just below 1.0 for both runs, indicating that the ANN index is able to return nearly correct results for all queries.
 2. The query times for both ANN are 6 times les then for exact k-NN. 

--- a/tasks/SOLUTION.md
+++ b/tasks/SOLUTION.md
@@ -2,8 +2,21 @@
 
 ```
 stdout of the solution script for the task
+Average precision@10: 1.0000
+Average ANN query time: 62.86 ms
+Average exact k-NN query time: 62.89 ms
+
+Average precision@10: 1.0000
+Average ANN query time: 66.96 ms
+Average exact k-NN query time: 65.99 ms
 ```
+
 
 ### Reflection
 
-Which patterns are present? How can they be explained? Describe your findings in detail here.
+1. The precision@10 is 1.0000 for both runs, indicating that the ANN index is able to return the correct results for all queries.
+2. The query times for both ANN and exact k-NN are very close. This means the ANN index is able to return results that are very similar to the exact k-NN results. 
+   * The ANN index has a similar accuracy as the k-NN index for a similar speed, for the given dataset.
+3. Possible we have these good results for the ANN index because the test data set with only 100 embeddings is small.
+   * This means we can use the k-nn index for small datasets, without losing speed 
+   * Or we can use the ANN index for small datasets, without losing accuracy.

--- a/tasks/SOLUTION.md
+++ b/tasks/SOLUTION.md
@@ -1,22 +1,30 @@
 ### Observed values 
 
 ```
-stdout of the solution script for the task
-Average precision@10: 1.0000
-Average ANN query time: 62.86 ms
-Average exact k-NN query time: 62.89 ms
+TASK 3 - k-NN vs approximate search
+TO DO
 
-Average precision@10: 1.0000
-Average ANN query time: 66.96 ms
-Average exact k-NN query time: 65.99 ms
+TASK 2 - Balance the search: Fine-tuning search parameters (e.g. hsnw-ef)
+TO DO
+
+TASK 1 - Quantization
+Average precision@10: 0.9990
+Average ANN query time: 16.39 ms
+Average exact k-NN query time: 109.97 ms
+
+Average precision@10: 0.9990
+Average ANN query time: 15.61 ms
+Average exact k-NN query time: 97.63 ms
+
+Average precision@10: 0.9990
+Average ANN query time: 15.47 ms
+Average exact k-NN query time: 98.38 ms
+
 ```
 
 
 ### Reflection
-
-1. The precision@10 is 1.0000 for both runs, indicating that the ANN index is able to return the correct results for all queries.
-2. The query times for both ANN and exact k-NN are very close. This means the ANN index is able to return results that are very similar to the exact k-NN results. 
-   * The ANN index has a similar accuracy as the k-NN index for a similar speed, for the given dataset.
-3. Possible we have these good results for the ANN index because the test data set with only 100 embeddings is small.
-   * This means we can use the k-nn index for small datasets, without losing speed 
-   * Or we can use the ANN index for small datasets, without losing accuracy.
+After (forced) creating an index on the Qdrant client we get this better results.
+1. The precision@10 is 0.9990 or just below 1.0 for both runs, indicating that the ANN index is able to return nearly correct results for all queries.
+2. The query times for both ANN are 6 times les then for exact k-NN. 
+3. This means it is beneficial to use the  ANN index with 6x faster and near correct accuracy for the test set.

--- a/tasks/SOLUTION.md
+++ b/tasks/SOLUTION.md
@@ -5,7 +5,17 @@ TASK 3 - k-NN vs approximate search
 TO DO
 
 TASK 2 - Balance the search: Fine-tuning search parameters (e.g. hsnw-ef)
-TO DO
+hnsw_ef= 10 | avg_precision=0.9220 | avg_query_time=11.93 ms
+hnsw_ef= 20 | avg_precision=0.9770 | avg_query_time=11.91 ms
+hnsw_ef= 50 | avg_precision=0.9980 | avg_query_time=13.71 ms
+hnsw_ef=100 | avg_precision=0.9990 | avg_query_time=17.28 ms
+hnsw_ef=200 | avg_precision=0.9990 | avg_query_time=16.96 ms
+
+hnsw_ef= 10 | avg_precision=0.9220 | avg_query_time=14.36 ms
+hnsw_ef= 20 | avg_precision=0.9770 | avg_query_time=13.42 ms
+hnsw_ef= 50 | avg_precision=0.9980 | avg_query_time=14.91 ms
+hnsw_ef=100 | avg_precision=0.9990 | avg_query_time=14.63 ms
+hnsw_ef=200 | avg_precision=0.9990 | avg_query_time=16.29 ms
 
 TASK 1 - Quantization
 Average precision@10: 0.9990
@@ -19,11 +29,20 @@ Average exact k-NN query time: 97.63 ms
 Average precision@10: 0.9990
 Average ANN query time: 15.47 ms
 Average exact k-NN query time: 98.38 ms
-
 ```
 
 
 ### Reflection
+
+TASK 3 - k-NN vs approximate search
+
+
+TASK 2 - Balance the search: Fine-tuning search parameters (e.g. hsnw-ef)
+1. We see the average precision fundamentally improves to >0.99 from hnsw_ef = 50
+2. While the average execution speed remains more or less the same for each value of hnsw_ef
+3. So we propose to use a value for hnsw_ef of 50. 
+
+TASK 1 - Quantization
 After (forced) creating an index on the Qdrant client we get this better results.
 1. The precision@10 is 0.9990 or just below 1.0 for both runs, indicating that the ANN index is able to return nearly correct results for all queries.
 2. The query times for both ANN are 6 times les then for exact k-NN. 

--- a/tasks/SOLUTION.md
+++ b/tasks/SOLUTION.md
@@ -1,7 +1,7 @@
 ### Observed values 
 
 ```
-TASK 3 - Quantization
+TASK 3 - Quantization 
 TO DO
 
 TASK 2 - Balance the search: Fine-tuning search parameters (e.g. hsnw-ef)
@@ -17,7 +17,7 @@ hnsw_ef= 50 | avg_precision=0.9980 | avg_query_time=14.91 ms
 hnsw_ef=100 | avg_precision=0.9990 | avg_query_time=14.63 ms
 hnsw_ef=200 | avg_precision=0.9990 | avg_query_time=16.29 ms
 
-TASK 1 - k-NN vs approximate search
+TASK 1 - k-NN vs approximate search 
 Average precision@10: 0.9990
 Average ANN query time: 16.39 ms
 Average exact k-NN query time: 109.97 ms
@@ -34,7 +34,7 @@ Average exact k-NN query time: 98.38 ms
 
 ### Reflection
 
-TASK 3 - Quantization
+TASK 3 - Quantization 
 
 
 TASK 2 - Balance the search: Fine-tuning search parameters (e.g. hsnw-ef)
@@ -42,7 +42,7 @@ TASK 2 - Balance the search: Fine-tuning search parameters (e.g. hsnw-ef)
 2. While the average execution speed remains more or less the same for each value of hnsw_ef
 3. So we propose to use a value for hnsw_ef of 50. 
 
-TASK 1 - k-NN vs approximate search
+TASK 1 - k-NN vs approximate search 
 After (forced) creating an index on the Qdrant client we get this better results.
 1. The precision@10 is 0.9990 or just below 1.0 for both runs, indicating that the ANN index is able to return nearly correct results for all queries.
 2. The query times for both ANN are 6 times les then for exact k-NN. 


### PR DESCRIPTION
## Task

Which task does this PR submit? (delete the ones that don't apply)

- [X] Task 2 — Balance the search (`hnsw_ef` sweep)


Branch name: `task-2`

## Summary

Used a forced index for the Qdrant client, created under task_1.
Implemented task-2 as requested, creating only the one requested function:

- Calculate ground truths
- For each hsnw_value
   - Warm up cache
   - For every embedding: Calculate ANN & precision
   - Calculate averages (execution time, precision)
- print result

## Checklist

- [x] Qdrant is running locally and the `arxiv_papers` collection from the Vector database with Qdrant project is populated
- [x] The script runs end-to-end without errors against the [test dataset](../dataset/queries_embeddings.json)
- [x] `tasks/SOLUTION.md` is filled out with the observed values and reflection for this task
- [x] This PR targets the correct task branch (one task per PR/branch)